### PR TITLE
Update start-dev-environment.md

### DIFF
--- a/docs/start-dev-environment.md
+++ b/docs/start-dev-environment.md
@@ -40,6 +40,8 @@ docker-compose run web rake db:create
 docker-compose run web rake db:reset
 docker-compose up
 ```
+Note: some users may need to prepend `bundle exec` to the web container `rake` commands (e.g. `docker-compose run web bundle exec rake db:create`)
+
 Open a new terminal and start the front-end with :
 ```bash
 cd front


### PR DESCRIPTION
On my local setup when running: 
`docker-compose run web rake db:reset`

The error message is clear enough - but thought someone on the inside could decide if this is a valid documentation improvement. 
```
Gem::LoadError: You have already activated rake 13.0.1, but your Gemfile requires rake 13.0.6. Prepending `bundle exec` to your command may solve this.
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler/runtime.rb:308:in `check_for_activated_spec!'
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler/runtime.rb:25:in `block in setup'
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler/spec_set.rb:135:in `each'
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler/spec_set.rb:135:in `each'
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler/runtime.rb:24:in `map'
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler/runtime.rb:24:in `setup'
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler.rb:163:in `setup'
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler/setup.rb:10:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler/ui/shell.rb:136:in `with_level'
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler/ui/shell.rb:88:in `silence'
/usr/local/bundle/gems/bundler-2.3.20/lib/bundler/setup.rb:10:in `<top (required)>'
/cl2_back/config/boot.rb:21:in `<top (required)>'
/cl2_back/config/application.rb:3:in `require_relative'
/cl2_back/config/application.rb:3:in `<top (required)>'
/cl2_back/rakefile:6:in `require_relative'
/cl2_back/rakefile:6:in `<top (required)>'
(See full trace by running task with --trace)
```